### PR TITLE
Improve rate limiter pacing and 429 penalty handling

### DIFF
--- a/src/ApiSports.Sdk.Abstractions/IApiSportsRateLimiter.cs
+++ b/src/ApiSports.Sdk.Abstractions/IApiSportsRateLimiter.cs
@@ -1,6 +1,10 @@
-﻿namespace ApiSports.Sdk.Abstractions;
+﻿using System.Net;
+
+namespace ApiSports.Sdk.Abstractions;
 
 public interface IApiSportsRateLimiter
 {
     Task WaitAsync(ApiSportsRequestContext context, CancellationToken ct);
+
+    void Report(ApiSportsRequestContext context, HttpStatusCode statusCode, TimeSpan? retryAfter);
 }

--- a/src/ApiSports.Sdk.Abstractions/RateLimitOptions.cs
+++ b/src/ApiSports.Sdk.Abstractions/RateLimitOptions.cs
@@ -24,6 +24,21 @@ public sealed class RateLimitOptions
     public TimeSpan? StatusCacheDuration { get; set; }
 
     /// <summary>
+    /// Safety factor applied to the base requests-per-minute before pacing.
+    /// </summary>
+    public double SafetyFactor { get; set; } = 0.85;
+
+    /// <summary>
+    /// Default penalty applied when receiving a 429 response.
+    /// </summary>
+    public TimeSpan PenaltyDuration { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Maximum penalty to apply when honoring Retry-After.
+    /// </summary>
+    public TimeSpan RetryAfterPenaltyCap { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
     /// If true, the client tries to not exceed the limits using the info read from the headers.
     /// </summary>
     public bool EnableClientSideThrottling { get; set; } = true;

--- a/src/ApiSports.Sdk.Core/ApiSportsClientFactory.cs
+++ b/src/ApiSports.Sdk.Core/ApiSportsClientFactory.cs
@@ -41,7 +41,7 @@ public static class ApiSportsClientFactory
             InnerHandler = apiKeyHandler
         };
 
-        RateLimitEnforcementHandler enforcementHandler = new RateLimitEnforcementHandler(finalStore, options.RateLimit, scope)
+        RateLimitEnforcementHandler enforcementHandler = new RateLimitEnforcementHandler(finalStore, options.RateLimit, scope, rateLimiter, requestContext)
         {
             InnerHandler = trackingHandler
         };

--- a/src/ApiSports.Sdk.Core/ApiSportsPacingRateLimiter.cs
+++ b/src/ApiSports.Sdk.Core/ApiSportsPacingRateLimiter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Net;
 using ApiSports.Sdk.Abstractions;
 using ApiSports.Sdk.Abstractions.Models.Common;
 
@@ -19,14 +20,15 @@ internal sealed class ApiSportsPacingRateLimiter(
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        int requestsPerMinute = await ResolveRequestsPerMinuteAsync(context, ct).ConfigureAwait(false);
+        int baseRequestsPerMinute = await ResolveRequestsPerMinuteAsync(context, ct).ConfigureAwait(false);
 
-        if (requestsPerMinute <= 0)
+        if (baseRequestsPerMinute <= 0)
         {
             throw new InvalidOperationException("Requests per minute must be greater than zero.");
         }
 
-        TimeSpan interval = ComputeInterval(requestsPerMinute);
+        int effectiveRequestsPerMinute = ComputeEffectiveRequestsPerMinute(baseRequestsPerMinute, _options.SafetyFactor);
+        TimeSpan interval = ComputeInterval(effectiveRequestsPerMinute);
         string key = GetKey(context);
         RateLimiterState state = _states.GetOrAdd(key, _ => new RateLimiterState());
 
@@ -34,6 +36,34 @@ internal sealed class ApiSportsPacingRateLimiter(
         if (delayTicks > 0)
         {
             await Task.Delay(TimeSpan.FromTicks(delayTicks), ct).ConfigureAwait(false);
+        }
+    }
+
+    public void Report(ApiSportsRequestContext context, HttpStatusCode statusCode, TimeSpan? retryAfter)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if ((int)statusCode != 429)
+        {
+            return;
+        }
+
+        TimeSpan penalty = ComputePenalty(retryAfter);
+        if (penalty <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        string key = GetKey(context);
+        RateLimiterState state = _states.GetOrAdd(key, _ => new RateLimiterState());
+        long penaltyUntilTicks = DateTimeOffset.UtcNow.UtcTicks + penalty.Ticks;
+
+        lock (state.Sync)
+        {
+            if (penaltyUntilTicks > state.PenaltyUntilTicks)
+            {
+                state.PenaltyUntilTicks = penaltyUntilTicks;
+            }
         }
     }
 
@@ -180,6 +210,13 @@ internal sealed class ApiSportsPacingRateLimiter(
         return TimeSpan.FromTicks(ticks);
     }
 
+    internal static int ComputeEffectiveRequestsPerMinute(int baseRequestsPerMinute, double safetyFactor)
+    {
+        double scaled = Math.Floor(baseRequestsPerMinute * safetyFactor);
+        int effective = (int)scaled;
+        return effective < 1 ? 1 : effective;
+    }
+
     private static long ScheduleDelayTicks(RateLimiterState state, TimeSpan interval)
     {
         long nowTicks = DateTimeOffset.UtcNow.UtcTicks;
@@ -188,7 +225,22 @@ internal sealed class ApiSportsPacingRateLimiter(
         lock (state.Sync)
         {
             long nextAllowed = state.NextAllowedTicks;
-            scheduledTicks = nowTicks > nextAllowed ? nowTicks : nextAllowed;
+
+            if (!state.IsInitialized)
+            {
+                scheduledTicks = nowTicks + interval.Ticks;
+                state.IsInitialized = true;
+            }
+            else
+            {
+                scheduledTicks = nowTicks > nextAllowed ? nowTicks : nextAllowed;
+            }
+
+            if (state.PenaltyUntilTicks > scheduledTicks)
+            {
+                scheduledTicks = state.PenaltyUntilTicks;
+            }
+
             state.NextAllowedTicks = scheduledTicks + interval.Ticks;
         }
 
@@ -206,6 +258,10 @@ internal sealed class ApiSportsPacingRateLimiter(
         public object Sync { get; } = new();
 
         public long NextAllowedTicks;
+
+        public long PenaltyUntilTicks;
+
+        public bool IsInitialized;
     }
 
     private sealed class ResolutionState
@@ -216,4 +272,20 @@ internal sealed class ApiSportsPacingRateLimiter(
     }
 
     private sealed record RateLimitResolution(int RequestsPerMinute, DateTimeOffset? ExpiresAt);
+
+    private TimeSpan ComputePenalty(TimeSpan? retryAfter)
+    {
+        if (retryAfter.HasValue && retryAfter.Value > TimeSpan.Zero)
+        {
+            TimeSpan cap = _options.RetryAfterPenaltyCap;
+            if (cap > TimeSpan.Zero && retryAfter.Value > cap)
+            {
+                return cap;
+            }
+
+            return retryAfter.Value;
+        }
+
+        return _options.PenaltyDuration;
+    }
 }

--- a/tests/ApiSports.Sdk.Core.Tests/PacingRateLimiterTests.cs
+++ b/tests/ApiSports.Sdk.Core.Tests/PacingRateLimiterTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using ApiSports.Sdk.Abstractions;
 using Xunit;
 
@@ -51,7 +52,7 @@ public sealed class PacingRateLimiterTests
         RateLimitOptions options = new()
         {
             ResolutionMode = RateLimitResolutionMode.Custom,
-            CustomRequestsPerMinute = 60
+            CustomRequestsPerMinute = 600
         };
 
         ApiSportsPacingRateLimiter limiter = new(options, new StubStatusClient());
@@ -69,16 +70,77 @@ public sealed class PacingRateLimiterTests
         DateTimeOffset[][] results = await Task.WhenAll(sequenceA, sequenceB);
         stopwatch.Stop();
 
-        var interval = TimeSpan.FromSeconds(1);
-        var tolerance = TimeSpan.FromMilliseconds(150);
+        TimeSpan interval = TimeSpan.FromMilliseconds(100);
+        TimeSpan tolerance = TimeSpan.FromMilliseconds(50);
 
-        Assert.True(stopwatch.Elapsed < interval + TimeSpan.FromSeconds(1), "Keys did not progress independently.");
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1), "Keys did not progress independently.");
 
         foreach (DateTimeOffset[] result in results)
         {
             TimeSpan delta = result[1] - result[0];
             Assert.True(delta >= interval - tolerance, $"Delta {delta} was below expected interval.");
         }
+    }
+
+    [Fact]
+    public async Task WaitAsync_WarmsUpOnFirstUse()
+    {
+        RateLimitOptions options = new()
+        {
+            ResolutionMode = RateLimitResolutionMode.Custom,
+            CustomRequestsPerMinute = 60
+        };
+
+        ApiSportsPacingRateLimiter limiter = new(options, new StubStatusClient());
+        ApiSportsRequestContext context = ApiSportsRequestContext.FromBaseUri(
+            new Uri("https://v3.football.api-sports.io/"),
+            ApiSportsSport.Football);
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        await limiter.WaitAsync(context, CancellationToken.None);
+        stopwatch.Stop();
+
+        TimeSpan interval = TimeSpan.FromSeconds(1);
+        TimeSpan tolerance = TimeSpan.FromMilliseconds(150);
+
+        Assert.True(stopwatch.Elapsed >= interval - tolerance, $"Warm-up delay {stopwatch.Elapsed} was below expected interval.");
+    }
+
+    [Fact]
+    public void ComputeEffectiveRequestsPerMinute_AppliesSafetyFactor()
+    {
+        int effective = ApiSportsPacingRateLimiter.ComputeEffectiveRequestsPerMinute(60, 0.85);
+        Assert.Equal(51, effective);
+
+        int minimum = ApiSportsPacingRateLimiter.ComputeEffectiveRequestsPerMinute(1, 0.1);
+        Assert.Equal(1, minimum);
+    }
+
+    [Fact]
+    public async Task Report_429AppliesPenalty()
+    {
+        RateLimitOptions options = new()
+        {
+            ResolutionMode = RateLimitResolutionMode.Custom,
+            CustomRequestsPerMinute = 600,
+            PenaltyDuration = TimeSpan.FromMilliseconds(200)
+        };
+
+        ApiSportsPacingRateLimiter limiter = new(options, new StubStatusClient());
+        ApiSportsRequestContext context = ApiSportsRequestContext.FromBaseUri(
+            new Uri("https://v3.football.api-sports.io/"),
+            ApiSportsSport.Football);
+
+        await limiter.WaitAsync(context, CancellationToken.None);
+
+        limiter.Report(context, HttpStatusCode.TooManyRequests, null);
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        await limiter.WaitAsync(context, CancellationToken.None);
+        stopwatch.Stop();
+
+        TimeSpan tolerance = TimeSpan.FromMilliseconds(50);
+        Assert.True(stopwatch.Elapsed >= options.PenaltyDuration - tolerance, $"Penalty delay {stopwatch.Elapsed} was below expected minimum.");
     }
 
     private static async Task<DateTimeOffset[]> RunSequenceAsync(
@@ -89,7 +151,7 @@ public sealed class PacingRateLimiterTests
         var results = new DateTimeOffset[count];
         for (int i = 0; i < count; i++)
         {
-            await limiter.WaitAsync(context, CancellationToken.None).ConfigureAwait(false);
+            await limiter.WaitAsync(context, CancellationToken.None);
             results[i] = DateTimeOffset.UtcNow;
         }
 
@@ -100,7 +162,7 @@ public sealed class PacingRateLimiterTests
         ApiSportsPacingRateLimiter limiter,
         ApiSportsRequestContext context)
     {
-        await limiter.WaitAsync(context, CancellationToken.None).ConfigureAwait(false);
+        await limiter.WaitAsync(context, CancellationToken.None);
         return DateTimeOffset.UtcNow;
     }
 


### PR DESCRIPTION
### Motivation
- Reduce HTTP 429 occurrences by making pacing deterministic, conservative, and concurrency-safe per key (host + sport).
- Introduce a safety margin so the client never uses the full plan rpm for scheduling.
- Prevent immediate bursts on first use by imposing a warm-up slot and ensure retries go through the limiter.
- Apply cumulative penalties when the server returns HTTP 429 and respect `Retry-After` when present.

### Description
- Added new rate limit options `SafetyFactor`, `PenaltyDuration`, and `RetryAfterPenaltyCap` to `RateLimitOptions` and used a default safety factor of `0.85`.
- Extended `IApiSportsRateLimiter` with `Report(...)` and implemented it in `ApiSportsPacingRateLimiter` to support cumulative 429 penalties, warm-up scheduling (first scheduled slot = now + interval), and effective rpm computation via `ComputeEffectiveRequestsPerMinute` (floor + minimum 1).
- Integrated limiter reporting and retry-aware behavior into the pipeline by calling `_rateLimiter.Report(...)` from `ApiSportsHttpClient` (with a `TryGetRetryAfter` helper) and by wiring the pacing limiter into `RateLimitEnforcementHandler` so retries invoke the limiter before sending.
- Updated `ApiSportsClientFactory` to pass the pacing limiter and `ApiSportsRequestContext` into the enforcement handler, and added unit tests in `PacingRateLimiterTests.cs` for safety factor math, warm-up behavior, 429 penalty timing, and per-key isolation, plus small test adjustments (timings and removal of `ConfigureAwait` in tests).

### Testing
- Executed the solution test runner with `dotnet test /workspace/api-sports/api-sports.sln` and observed the test discovery/run process was attempted against all test projects.
- Also executed the core test project directly with `dotnet test tests/ApiSports.Sdk.Core.Tests/ApiSports.Sdk.Core.Tests.csproj` and built the test assembly; the build succeeded but VSTest reported "No test is available" for the net10.0 test assemblies so tests were not actually executed.
- Addressed an xUnit analyzer warning by removing `ConfigureAwait(false)` calls in test helpers, re-ran the test commands, and confirmed the discovery issue persisted rather than a failing assertion.
- Because the test runner did not discover tests for the net10.0 test assemblies, automated tests could not be verified as passing in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695adf4168248326a74f6e49513a1477)